### PR TITLE
Add OSVER parameter

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -41,10 +41,11 @@ if [[ $BVER =~ $VERSION_REGEX ]] ; then
  fi
  TARGET_VERSION=$BVER
 elif [ $BROWSER == "safari" ] && [ $BVER == "unstable" ]; then
+  OSVER="${OSVER:-10.12}"
   # This is quite dangerous, it is scraping the safari download website for the URL. If the format
   # of the website changes then it won't work anymore. We should add safari to
   # browsers.contralis.info instead
-  TARGET_URL=`curl https://developer.apple.com/safari/download/ | sed -nE 's/.*href="(.*\.dmg)">.*macOS 10.12.*/\1/p'`
+  TARGET_URL=`curl https://developer.apple.com/safari/download/ | sed -nE "s/.*href=\"(.*\.dmg)\">.*macOS $OSVER.*/\1/p"`
   TARGET_VERSION=`curl https://developer.apple.com/safari/download/ | sed -nE 's/.*>([0-9]+)<\/p>.*$/\1/p'`
 else
   TARGET_BROWSER=`curl -H 'Accept: text/csv' https://browser-version-api.herokuapp.com/$PLATFORM/$BROWSER/$BVER`


### PR DESCRIPTION
Adds OSVER parameter, allowing users to specify the version of the OS the tests should target (useful because Safari's Technology Preview pages now longer have download links for MacOS 10.12)