### PR TITLE
version change to solve travis-multirunner

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "dependencies": {
     "djo-shell": "^1.0.0",
     "formatter": "^0.4.1",
-    "normalize-package-data": "^2.3.8"
+    "normalize-package-data": "^5.0.0"
   }
 }


### PR DESCRIPTION
Issues with:
- `path-parse` @ 1.0.6
- `hosted-git-info` @ 2.8.8

Updating `normalize-package-data`:
- removes dependency for `resolve` which carries the `path-parse` vulnerability.
- upgrades `hosted-git-info` to 6.0.0, which eliminates vulnerability present in 2.8.8